### PR TITLE
async_read: Use yield instead of self-paced generator solution in return statement

### DIFF
--- a/async_read.py
+++ b/async_read.py
@@ -8,10 +8,7 @@ def async_generator(callback):
     thread = Thread(target=lambda: return_value.append(callback()))
     thread.start()
 
-    return (
-        thread.join() or return_value[0]
-        for _ in [None]
-    )
+    yield thread.join() or return_value[0]
 
 def async_lines(path):
     def read_lines():


### PR DESCRIPTION
The statement 
```
return (
        thread.join() or return_value[0]
        for _ in [None]
    )
```
can be shortened using the `yield`-statement into
```
yield thread.join() or return_value[0]
```